### PR TITLE
Remove extra unique taskID from task config

### DIFF
--- a/tasks/styleguide.js
+++ b/tasks/styleguide.js
@@ -83,9 +83,9 @@ module.exports = function(grunt) {
 
 
    function runMultiTask(name, config) {
-      var taskID = _.uniqueId('styleguide-subtask-');
-      grunt.config(name + '.' + taskID, config);
-      grunt.task.run(name + ':' + taskID);
+      var label = 'styleguide-subtask';
+      grunt.config(name + '.' + label, config);
+      grunt.task.run(name + ':' + label);
    }
 
 


### PR DESCRIPTION
Because a unique taskID was being appended to the end of each
styleguide subtask, multiple identical subtasks were getting
added to the grunt config. For example, every time a change
was made to a styleguide file, instead of running the same
styleguide subtask, a new task would be added to the list.
E.g. "sass:styleguide-subtask-1", "sass:styleguide-subtask-2",
etc. Then, these tasks would live in the grunt config, and if
ever the 'sass' task ran, it would run all numbered styleguide
subtasks.

Because the prefix "sass:" or "browserify:" would serve to
keep different types of tasks unique in the tasklist, it is safe
to remove the unique ID postfix. Removing the unique ID allows
grunt to keep one record of each unique subtask, and run those
only.